### PR TITLE
Fix lookup for GSL

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -32,6 +32,8 @@ end
 
 if /mingw/ =~ RUBY_PLATFORM
   GSL_CONFIG = "sh gsl-config"
+elsif File.exist?("/app/vendor/gsl/bin/gsl-config")
+  GSL_CONFIG = "/app/vendor/gsl/bin/gsl-config"
 else
   GSL_CONFIG = "gsl-config"
 end


### PR DESCRIPTION
The rb-gsl gem's extconf.rb was hardcoded to run gsl-config from PATH, which failed on Heroku where GSL is installed at /app/vendor/gsl/bin/gsl-config.

The fix makes the gem automatically check for gsl-config at the Heroku location first, before falling back to standard locations, ensuring it can find GSL during gem compilation.