### PR TITLE
Fix compilation on Ruby 3.1+ with modern Clang compilers

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -135,8 +135,7 @@ def check_version(configfile)
 end
 
 #####
-
-$CFLAGS = " -Wall -I../include "
+$CFLAGS = " -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion -Wno-error=implicit-function-declaration -Wall -I../include "
 
 begin
   RB_GSL_CONFIG = File.open("../include/rb_gsl_config.h", "w")


### PR DESCRIPTION
Add compiler flags to treat function pointer mismatches and implicit declarations as warnings rather than errors, allowing compilation to succeed on modern toolchains while maintaining backward compatibility.